### PR TITLE
Use args in an exact order for partial match search

### DIFF
--- a/README.md
+++ b/README.md
@@ -441,6 +441,12 @@ Default is `true`.
 
         CDA_BASH_COMPLETION=true
 
+* CDA_MATCH_EXACT_ORDER
+Set to false if you want to use the second and subsequent arguments in no particular order for partial match search.  
+The default is `true`.
+
+        CDA_MATCH_EXACT_ORDER=true
+
 * CDA_CMD_FILTER  
 Specify the name or path of interactive filter commands to select an alias from list when no argument is given or multiple aliases are hit.  
 `-F` `--cmd-filter` can override this.

--- a/README.md
+++ b/README.md
@@ -48,8 +48,7 @@ $ git clone https://github.com/itmst71/cda.git
 ## Homebrew
 
 ```console
-$ brew tap itmst71/tools
-$ brew install cda
+$ brew install itmst71/tools/cda
 ```
 
 * `source cda.sh` in `~/.bashrc` or `~/.zshrc`
@@ -182,33 +181,45 @@ $ cda -F fzf
 
 ### Internal Filter
 * `cda` itself also has the simple non-interactive filter.  
-***The first argument is always used for forward match searches.***
+***The first argument is always used for forward matching search.***
 ```console
-$ cda -l
-abcefg1       /qux/baz/bar/foo1
-abcgfe1       /qux/baz/bar/foo2
-abcabcefg1    /qux/baz/bar/foo3
-axcxyz1       /qux/baz/bar/foo4
-axcxyz11      /qux/baz/bar/foo5
-axcxyz121     /qux/baz/bar/foo6
-bbcefg1       /qux/baz/bar/foo7
-$ cda -l b
-bbcefg1       /qux/baz/bar/foo7
+$ cda --list-names       # Print only names
+lindows
+linux
+linuxmint
+lubuntu
+macosx
+manjarolinux
+
+$ cda --list-names l     # The first argument "l" is always used for forward matching
+lindows
+linux
+linuxmint
+lubuntu
 ```
 
-* The second and subsequent arguments are used for unordered partial AND match search after forward match search with the first argument.
+* The second and subsequent arguments are used in an exact order for partial matching.  
+
 ```console
-$ cda -l a f
-abcefg1       /qux/baz/bar/foo1
-abcgfe1       /qux/baz/bar/foo2
-abcabcefg1    /qux/baz/bar/foo3
-$ cda -l a f a
-abcabcefg1    /qux/baz/bar/foo3
-$ cda -l ax 11
-axcxyz11      /qux/baz/bar/foo5
-$ cda a 2
-$ pwd
-/qux/baz/bar/foo6
+$ cda --list-names l u t
+linuxmint
+lubuntu
+
+$ cda --list-names l t u
+lubuntu
+```
+
+* if you set `CDA_MATCH_EXACT_ORDER=false`, the second and subsequent arguments are used in no particular order.  
+This behavior is the same as `v1.3.0` or lower.
+
+```console
+$ cda --list-names l u t
+linuxmint
+lubuntu
+
+$ cda --list-names l t u
+linuxmint
+lubuntu
 ```
 
 ## Intermediate Level

--- a/cda.sh
+++ b/cda.sh
@@ -100,6 +100,7 @@ _cda()
     # default config variables
     declare -r CDA_EXEC_NAME_DEFAULT=cda
     declare -r CDA_BASH_COMPLETION_DEFAULT=true
+    declare -r CDA_MATCH_EXACT_ORDER_DEFAULT=true
     declare -r CDA_CMD_FILTER_DEFAULT="percol:peco:fzf:fzy"
     declare -r CDA_CMD_OPEN_DEFAULT="xdg-open:open:ranger:mc"
     declare -r CDA_CMD_EDITOR_DEFAULT="vim:nano:emacs:vi"
@@ -426,6 +427,7 @@ _cda::setup::init()
     fi
 
     CDA_FILTER_LINE_PREFIX="${CDA_FILTER_LINE_PREFIX:-$CDA_FILTER_LINE_PREFIX_DEFAULT}"
+    CDA_MATCH_EXACT_ORDER="${CDA_MATCH_EXACT_ORDER:-$CDA_MATCH_EXACT_ORDER_DEFAULT}"
 
     # set initialized flag
     CDA_INITIALIZED=true
@@ -654,6 +656,7 @@ _cda::config::create()
 << __EOCFG__ \cat > "$CONFIG_FILE"
 # CDA_EXEC_NAME=$CDA_EXEC_NAME_DEFAULT
 # CDA_BASH_COMPLETION=$CDA_BASH_COMPLETION_DEFAULT
+# CDA_MATCH_EXACT_ORDER=$CDA_MATCH_EXACT_ORDER_DEFAULT
 # CDA_CMD_FILTER=$CDA_CMD_FILTER_DEFAULT
 # CDA_CMD_OPEN=$CDA_CMD_OPEN_DEFAULT
 # CDA_CMD_EDITOR=$CDA_CMD_EDITOR_DEFAULT
@@ -675,6 +678,7 @@ CDA_SRC_FILE="$CDA_SRC_FILE"
 CDA_DATA_ROOT="$CDA_DATA_ROOT"
 CDA_EXEC_NAME=${CDA_EXEC_NAME:-$CDA_EXEC_NAME_DEFAULT}
 CDA_BASH_COMPLETION=${CDA_BASH_COMPLETION:-$CDA_BASH_COMPLETION_DEFAULT}
+CDA_MATCH_EXACT_ORDER=${CDA_MATCH_EXACT_ORDER:-$CDA_MATCH_EXACT_ORDER_DEFAULT}
 CDA_CMD_FILTER=${CDA_CMD_FILTER:-$CDA_CMD_FILTER_DEFAULT}
 CDA_CMD_OPEN=${CDA_CMD_OPEN:-$CDA_CMD_OPEN_DEFAULT}
 CDA_CMD_EDITOR=${CDA_CMD_EDITOR:-$CDA_CMD_EDITOR_DEFAULT}
@@ -1192,6 +1196,13 @@ _cda::list::match()
         if [[ ${#args[@]} -eq 1 ]]; then
             printf -- "%b\n" "$lines"
             return 0
+
+        # in an exact order
+        elif _cda::utils::is_true "$CDA_MATCH_EXACT_ORDER"; then
+            regexp="^($(_cda::text::join '[^ ]*' ${args[@]})[^ ]* +)"
+            lines="$(printf -- "%b" "$lines" | \grep -E "$regexp")"
+
+        # in no particular order
         else
             \unset args[0]
             args=("${args[@]}")
@@ -1201,9 +1212,9 @@ _cda::list::match()
                 regexp="^${firstArg}[^ ]*${name}[^ ]* +"
                 lines="$(printf -- "%b" "$lines" | \grep -E "$regexp")"
                 [[ -z "$lines" ]] && break
-            done 
-            [[ -n "$lines" ]] && printf -- "%b\n" "$lines"
+            done
         fi
+        [[ -n "$lines" ]] && printf -- "%b\n" "$lines"
     fi
 }
 
@@ -2548,9 +2559,16 @@ CONFIG VARIABLES
 
     [ CDA_BASH_COMPLETION ]
         Set to false if you don't want to use Bash-Completion.
-        The defalt is true.
+        The default is true.
 
             CDA_BASH_COMPLETION=true
+
+    [ CDA_MATCH_EXACT_ORDER ]
+        Set to false if you want to use the second and subsequent
+        arguments in no particular order for partial match search.
+        The default is true.
+
+            CDA_MATCH_EXACT_ORDER=$CDA_MATCH_EXACT_ORDER_DEFAULT
 
     [ CDA_CMD_FILTER ]
         Specify the name or path of interactive filter commands
@@ -2589,7 +2607,7 @@ CONFIG VARIABLES
 
     [ CDA_AUTO_ALIAS ]
         Set to false if you don't want to use the auto-alias in terminal
-        multiplexer feature. The defalt is true.
+        multiplexer feature. The default is true.
 
             CDA_AUTO_ALIAS=true
 


### PR DESCRIPTION
* Use the second and subsequent arguments in an exact order for partial match search by default
`cda a b c` matches `abc` but `cda a c b` doesn't match.  
In previous versions both `cda a b c` and `cda a c b` matched `abc`.

* Added `CDA_MATCH_EXACT_ORDER` config variable
Setting to `false`, the behavior becomes the same as previous versions.
The default is `true`.
